### PR TITLE
Optimize datatypes of network states

### DIFF
--- a/sponet/cnvm/model.py
+++ b/sponet/cnvm/model.py
@@ -103,7 +103,7 @@ class CNVM:
         if self.params.network_generator is not None:
             self.update_network()
 
-        opinion_dtype = np.min_scalar_type(self.params.num_opinions)
+        opinion_dtype = np.min_scalar_type(self.params.num_opinions-1)
 
         if x_init is None:
             x_init = rng.choice(

--- a/sponet/cnvm/model.py
+++ b/sponet/cnvm/model.py
@@ -103,11 +103,13 @@ class CNVM:
         if self.params.network_generator is not None:
             self.update_network()
 
+        opinion_dtype = np.min_scalar_type(self.params.num_opinions)
+
         if x_init is None:
             x_init = rng.choice(
                 np.arange(self.params.num_opinions), size=self.params.num_agents
             )
-        x = np.copy(x_init).astype(int)
+        x = np.copy(x_init).astype(opinion_dtype)
 
         t_delta = 0 if len_output is None else t_max / (len_output - 1)
 
@@ -142,7 +144,7 @@ class CNVM:
             )
 
         t_traj = np.array(t_traj)
-        x_traj = np.array(x_traj, dtype=int)
+        x_traj = np.array(x_traj, dtype=opinion_dtype)
         if len_output is None:
             # remove duplicate subsequent states
             mask = mask_subsequent_duplicates(x_traj)

--- a/sponet/multiprocessing.py
+++ b/sponet/multiprocessing.py
@@ -152,7 +152,7 @@ def _sample_many_runs_subprocess(
 
     if collective_variable is None:
 
-        opinion_dtype = np.min_scalar_type(params.num_opinions)
+        opinion_dtype = np.min_scalar_type(params.num_opinions-1)
 
         x_out = np.zeros(
             (num_initial_states, num_runs, num_timesteps, model.params.num_agents),

--- a/sponet/multiprocessing.py
+++ b/sponet/multiprocessing.py
@@ -151,8 +151,12 @@ def _sample_many_runs_subprocess(
     model = model_type(params)
 
     if collective_variable is None:
+
+        opinion_dtype = np.min_scalar_type(params.num_opinions)
+
         x_out = np.zeros(
-            (num_initial_states, num_runs, num_timesteps, model.params.num_agents)
+            (num_initial_states, num_runs, num_timesteps, model.params.num_agents),
+            dtype=opinion_dtype
         )
     else:
         x_out = np.zeros(

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -116,30 +116,27 @@ class TestSampleManyRuns(TestCase):
         )
 
     def test_output_dtype_no_cv(self):
-        num_opinions_list = [2, 256]
+        num_opinions_list = [2, 257]
+        correct_dtype_list = [np.uint8, np.uint16]
 
-        for num_opinions in num_opinions_list:
-            r = np.ones((num_opinions, num_opinions))
-            r_tilde = np.ones((num_opinions, num_opinions))
-            np.fill_diagonal(r, 0)
-            np.fill_diagonal(r_tilde, 0)
+        for num_opinions, correct_dtype in zip(num_opinions_list, correct_dtype_list):
 
             params = CNVMParameters(
                 num_opinions=num_opinions,
                 num_agents=self.num_agents,
-                r=r,
-                r_tilde=r_tilde,
+                r=1,
+                r_tilde=1,
             )
 
             t, x = sample_many_runs(
                 params=params,
                 initial_states=self.initial_states,
-                t_max=self.t_max,
+                t_max=5,
                 num_timesteps=self.num_timesteps,
                 num_runs=2,
                 n_jobs=2,
                 collective_variable=None,
             )
 
-            self.assertEqual(np.min_scalar_type(num_opinions), x.dtype)
+            self.assertEqual(correct_dtype, x.dtype)
 

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -114,3 +114,32 @@ class TestSampleManyRuns(TestCase):
                 self.num_opinions,
             ),
         )
+
+    def test_output_dtype_no_cv(self):
+        num_opinions_list = [2, 256]
+
+        for num_opinions in num_opinions_list:
+            r = np.ones((num_opinions, num_opinions))
+            r_tilde = np.ones((num_opinions, num_opinions))
+            np.fill_diagonal(r, 0)
+            np.fill_diagonal(r_tilde, 0)
+
+            params = CNVMParameters(
+                num_opinions=num_opinions,
+                num_agents=self.num_agents,
+                r=r,
+                r_tilde=r_tilde,
+            )
+
+            t, x = sample_many_runs(
+                params=params,
+                initial_states=self.initial_states,
+                t_max=self.t_max,
+                num_timesteps=self.num_timesteps,
+                num_runs=2,
+                n_jobs=2,
+                collective_variable=None,
+            )
+
+            self.assertEqual(np.min_scalar_type(num_opinions), x.dtype)
+

--- a/tests/tests_cnvm/test_model.py
+++ b/tests/tests_cnvm/test_model.py
@@ -101,26 +101,22 @@ class TestModel(TestCase):
 
     def test_output_dtype(self):
 
-        num_opinions_list = [2, 256]
+        num_opinions_list = [2, 257]
+        correct_dtype_list = [np.uint8, np.uint16]
 
-        for num_opinions in num_opinions_list:
-            r = np.ones((num_opinions, num_opinions))
-            r_tilde = np.ones((num_opinions, num_opinions))
-            np.fill_diagonal(r, 0)
-            np.fill_diagonal(r_tilde, 0)
-
+        for num_opinions, correct_dtype in zip(num_opinions_list, correct_dtype_list):
             params = CNVMParameters(
                 num_opinions=num_opinions,
                 num_agents=self.num_agents,
-                r=r,
-                r_tilde=r_tilde,
+                r=1,
+                r_tilde=1,
             )
 
             model = CNVM(params)
             t_max = 5
             t, x = model.simulate(t_max)
 
-            self.assertEqual(np.min_scalar_type(num_opinions), x.dtype)
+            self.assertEqual(correct_dtype, x.dtype)
 
 
 

--- a/tests/tests_cnvm/test_model.py
+++ b/tests/tests_cnvm/test_model.py
@@ -36,6 +36,7 @@ class TestModel(TestCase):
             r_tilde=self.r_tilde,
         )
 
+
     def test_output(self):
         model = CNVM(self.params_complete)
         t_max = 100
@@ -97,3 +98,34 @@ class TestModel(TestCase):
 
         for i in range(x.shape[0] - 1):
             self.assertFalse(np.allclose(x[i], x[i + 1]))
+
+    def test_output_dtype(self):
+
+        num_opinions_list = [2, 256]
+
+        for num_opinions in num_opinions_list:
+            r = np.ones((num_opinions, num_opinions))
+            r_tilde = np.ones((num_opinions, num_opinions))
+            np.fill_diagonal(r, 0)
+            np.fill_diagonal(r_tilde, 0)
+
+            params = CNVMParameters(
+                num_opinions=num_opinions,
+                num_agents=self.num_agents,
+                r=r,
+                r_tilde=r_tilde,
+            )
+
+            model = CNVM(params)
+            t_max = 5
+            t, x = model.simulate(t_max)
+
+            self.assertEqual(np.min_scalar_type(num_opinions), x.dtype)
+
+
+
+
+
+
+
+


### PR DESCRIPTION
The dtypes for the network states in cnvm/model.simulate() and multiprocessing.sample_many_runs() were always int64 or float 64 which used unnecessary memory.
The dtypes are now determined by np.min_scalar_type(num_opinions).